### PR TITLE
Set API key from CLI

### DIFF
--- a/mayalabs/cli.py
+++ b/mayalabs/cli.py
@@ -1,12 +1,11 @@
 import os
-import platform
 import json
 import argparse
 from colorama import Fore, Style
+import mayalabs
 from .session import Session
 from .function import Function
 from .utils.name_gen import get_random_name
-import mayalabs
 
 MAYA_CACHE_FILE = os.path.join(os.path.expanduser("~"), ".mayalabs")
 
@@ -110,14 +109,6 @@ def show_post_instruct_options(recipe, session_id):
             exit()
         else:
             print(Style.BRIGHT + Fore.RED + 'Invalid choice. Please try again.' + Style.RESET_ALL)
-
-# if __name__ == "__main__":
-    # parser = argparse.ArgumentParser()
-    # parser.add_argument("function_name", help="The function to execute")
-    # parser.add_argument("-c", "--command", help="The command to pass to function")
-    # args = parser.parse_args()
-    # command = args.command
-    # instruct(command=command)
 
 def set_key(api_key):
     "Sets the API key provided using the -k option."

--- a/mayalabs/cli.py
+++ b/mayalabs/cli.py
@@ -17,14 +17,19 @@ def cli():
     parser = argparse.ArgumentParser()
     parser.add_argument("function_name", help="The function to execute")
     parser.add_argument("-c", "--command", help="The command to pass to function")
+    parser.add_argument("-k", "--key", help="The API Key to use")
     args = parser.parse_args()
     command = args.command
+    key = args.key
     function_name = args.function_name
     if function_name == "instruct" and not command:
         print("Please provide a command with the -c flag")
     elif function_name == "instruct" and command:
         instruct(command=command, from_scratch=True, session_id=None)
-
+    elif function_name == "set" and not key:
+        print("Please provide the API key with the -k flag")
+    elif function_name == "set" and key:
+        set_key(api_key=key)
 
 def get_api_key():
     """
@@ -113,3 +118,10 @@ def show_post_instruct_options(recipe, session_id):
     # args = parser.parse_args()
     # command = args.command
     # instruct(command=command)
+
+def set_key(api_key):
+    "Sets the API key provided using the -k option."
+    file_json = {"MAYA_API_KEY": api_key}
+    with open(MAYA_CACHE_FILE, "w+", encoding='UTF-8') as f:
+        f.write(json.dumps(file_json))
+        f.close()

--- a/mayalabs/cli.py
+++ b/mayalabs/cli.py
@@ -118,9 +118,24 @@ def show_post_instruct_options(recipe, session_id):
 def set_key(api_key):
     "Sets the API key provided using the -k option."
     file_json = {"MAYA_API_KEY": api_key}
-    with open(MAYA_CACHE_FILE, "w+", encoding='UTF-8') as f:
-        f.write(json.dumps(file_json))
-        f.close()
+
+    # Check if file exists
+    if os.path.isfile(MAYA_CACHE_FILE):
+        # Read existing data
+        with open(MAYA_CACHE_FILE, "r", encoding='UTF-8') as f:
+            data = json.load(f)
+            f.close()
+        # Update data
+        data["MAYA_API_KEY"] = api_key
+        # Write back to file
+        with open(MAYA_CACHE_FILE, "w", encoding='UTF-8') as f:
+            f.write(json.dumps(data))
+            f.close()
+    else:
+        # Create new file
+        with open(MAYA_CACHE_FILE, "w", encoding='UTF-8') as f:
+            f.write(json.dumps(file_json))
+            f.close()
 
 def whoami():
     "Display information about the user."

--- a/mayalabs/cli.py
+++ b/mayalabs/cli.py
@@ -125,7 +125,6 @@ def set_key(api_key):
 def whoami():
     "Display information about the user."
     url = f"{default_api_base_url()}/app/v2/profiles/whoami"
-    print(url)
     payload={}
     api_key = get_api_key(prompt_if_missing=False)
     if api_key:
@@ -135,4 +134,5 @@ def whoami():
         name_value = response_dict["name"]
         print(name_value)
     else:
-        print("You have not provided an API key. What you doing bruhhHhhh?")
+        print(Style.BRIGHT + Fore.RED + 'You have not provided an API key.' + Style.RESET_ALL)
+        print("You can set the API key using mayalabs set -k '<YOUR_API_KEY>'")


### PR DESCRIPTION
## Adds two functions to the CLI

### set
`mayalabs set -k '<YOUR_API_KEY>'`
This will set the api key to .mayalabs

### whoami
`mayalabs whoami`
Returns the name of the person whose API key is being used
